### PR TITLE
build(migrate): add GH_TOKEN, .releaserc for semantic-release

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -15,6 +15,7 @@ permissions:
 
 env:
   NPM_TOKEN: ${{ secrets.NPM_DEPLOYER_TOKEN || secrets.NPM_REGISTRY_REGISTRY_NPMJS_ORG_TOKEN }}
+  GH_TOKEN: ${{ secrets.GH_TOKEN }}
 
 jobs:
   run-checks-and-tests-and-publish:

--- a/.releaserc
+++ b/.releaserc
@@ -1,0 +1,3 @@
+{
+  "branches": ["main"]
+}


### PR DESCRIPTION
build(migrate): add GH_TOKEN, .releaserc for semantic-release
.releaserc specifies the non-default build branch 'main' . See [semantic-release docs](https://semantic-release.gitbook.io/semantic-release/usage/configuration#configuration-file) for more.
AA-16267

Co-authored-by: JonathanViau <jonathan.viau@sap.com>