### PR TITLE
fix(build): use credentials that allow github-actions to push

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -24,6 +24,8 @@ jobs:
     steps:
       - name: 📂 Checkout code
         uses: actions/checkout@v3
+        with:
+          token: ${{secrets.GH_TOKEN}}
 
       - name: 💚 Setup Node.js
         uses: actions/setup-node@v3


### PR DESCRIPTION
fix(build): use credentials that allow github-actions to push
github-actions is running afoul of our branch protections.  Branch protection policies don't allow an exception for github-actions.  Use [this solution](https://github.com/orgs/community/discussions/25305#discussioncomment-5582031) to use the emarsys-deploy policy exception. 
AA-16267

Co-authored-by: arnaudbuchholz-sap <arnaud.buchholz@sap.com>
