### PR TITLE
fix(build): use NPM_PUBLISHER_TOKEN

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -14,7 +14,7 @@ permissions:
   id-token: write
 
 env:
-  NPM_TOKEN: ${{ secrets.NPM_DEPLOYER_TOKEN || secrets.NPM_REGISTRY_REGISTRY_NPMJS_ORG_TOKEN }}
+  NPM_TOKEN: ${{ secrets.NPM_PUBLISHER_TOKEN }}
   GH_TOKEN: ${{ secrets.GH_TOKEN }}
 
 jobs:


### PR DESCRIPTION
fix(build): use NPM_PUBLISHER_TOKEN
semantic-release is failing on publishing to npm
AA-16267

Co-authored-by: arnaudbuchholz-sap <arnaud.buchholz@sap.com>